### PR TITLE
[feat] 회원 로그인 및 로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
 	//security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// JWT
+	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.sparta.vroomvroom.global.conmon.BaseResponse;
 import com.sparta.vroomvroom.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +25,8 @@ public class UserController {
         return new BaseResponse();
     }
 
+    //Todo: PR 병합시 삭제
+    @Secured({"ROLE_MANAGER","ROLE_CUSTOMER"})
     @GetMapping("/users/login/test")
     public BaseResponse testLogin(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         System.out.println(userDetails.getUser().getUserName());

--- a/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
@@ -3,12 +3,8 @@ package com.sparta.vroomvroom.domain.user.controller;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserSignupRequest;
 import com.sparta.vroomvroom.domain.user.service.UserService;
 import com.sparta.vroomvroom.global.conmon.BaseResponse;
-import com.sparta.vroomvroom.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,15 +18,6 @@ public class UserController {
             @Valid @RequestBody UserSignupRequest userSignupRequest
             ) {
         userService.signup(userSignupRequest);
-        return new BaseResponse();
-    }
-
-    //Todo: PR 병합시 삭제
-    @Secured({"ROLE_MANAGER","ROLE_CUSTOMER"})
-    @GetMapping("/users/login/test")
-    public BaseResponse testLogin(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        System.out.println(userDetails.getUser().getUserName());
-        System.out.println(userDetails.getUser().getUserId());
         return new BaseResponse();
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
@@ -3,12 +3,15 @@ package com.sparta.vroomvroom.domain.user.controller;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserSignupRequest;
 import com.sparta.vroomvroom.domain.user.service.UserService;
 import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import com.sparta.vroomvroom.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("api/v1")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
@@ -18,6 +21,13 @@ public class UserController {
             @Valid @RequestBody UserSignupRequest userSignupRequest
             ) {
         userService.signup(userSignupRequest);
+        return new BaseResponse();
+    }
+
+    @GetMapping("/users/login/test")
+    public BaseResponse testLogin(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        System.out.println(userDetails.getUser().getUserName());
+        System.out.println(userDetails.getUser().getUserId());
         return new BaseResponse();
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserLoginRequest.java
@@ -1,4 +1,22 @@
 package com.sparta.vroomvroom.domain.user.model.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class UserLoginRequest {
+    @NotBlank(message = "아이디는 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^[a-zA-Z0-9]{4,10}$",
+            message = "아이디는 영문과 숫자로 4~10자만 가능합니다.")
+    private String userName;
+
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{8,15}$",
+            message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함해 8~15자여야 합니다.")
+    private String password;
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserLoginRequest.java
@@ -1,0 +1,4 @@
+package com.sparta.vroomvroom.domain.user.model.dto.request;
+
+public class UserLoginRequest {
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserSignupRequest.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserSignupRequest.java
@@ -30,7 +30,6 @@ public class UserSignupRequest {
             message = "닉네임은 영문/한글/숫자로 5~20자만 가능합니다.")
     private String nickName;
 
-    //Todo: Enum 생성
     @NotNull(message = "회원 타입은 필수 입력 항목입니다.")
     private UserType type;
 
@@ -40,7 +39,6 @@ public class UserSignupRequest {
             message = "이름은 영문과 한글만, 최대 20자까지 가능합니다.")
     private String name;
 
-    //Todo: birthDay로 변경 제안
     @NotNull(message = "생일은 필수 입력 항목입니다.")
     @Past(message = "생일은 오늘 이전 날짜여야 합니다.")
     private LocalDate birthDate;
@@ -62,7 +60,6 @@ public class UserSignupRequest {
     @Size(max = 50, message = "이메일은 최대 50자까지 가능합니다.")
     private String email;
 
-    //todo: 명세서에 role 받는거 추가하기
     @NotNull(message = "권한은 필수 입력 항목입니다.")
     private UserRole role;
 

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserSignupRequest.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/dto/request/UserSignupRequest.java
@@ -66,5 +66,4 @@ public class UserSignupRequest {
     @NotNull(message = "권한은 필수 입력 항목입니다.")
     private UserRole role;
 
-
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/BlackList.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/BlackList.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -16,6 +17,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @Table(name = "black_lists")
+@EntityListeners(AuditingEntityListener.class)
 public class BlackList {
     @Id
     @GeneratedValue(strategy=GenerationType.UUID)
@@ -29,9 +31,8 @@ public class BlackList {
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    @CreatedBy
-    @Column(name = "created_by",updatable = false, nullable = false, length = 20)
-    private String createdBy;
+    //Todo: ERD, 설계문서에서 CreatedBy 삭제 - 로직상 존재 불가능
+
 
     public BlackList(String token) {
         this.token = token;

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/BlackList.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/BlackList.java
@@ -32,4 +32,8 @@ public class BlackList {
     @CreatedBy
     @Column(name = "created_by",updatable = false, nullable = false, length = 20)
     private String createdBy;
+
+    public BlackList(String token) {
+        this.token = token;
+    }
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/BlackList.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/BlackList.java
@@ -31,8 +31,6 @@ public class BlackList {
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    //Todo: ERD, 설계문서에서 CreatedBy 삭제 - 로직상 존재 불가능
-
 
     public BlackList(String token) {
         this.token = token;

--- a/src/main/java/com/sparta/vroomvroom/domain/user/repository/BlackListRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/repository/BlackListRepository.java
@@ -2,7 +2,10 @@ package com.sparta.vroomvroom.domain.user.repository;
 
 import com.sparta.vroomvroom.domain.user.model.entity.BlackList;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 import java.util.UUID;
 
 public interface BlackListRepository extends JpaRepository<BlackList, UUID> {
+    Optional<BlackList> findByToken(String token);
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/repository/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserNameOrEmailOrPhoneNumber(String userName, String email, String phoneNumber);
 
-    Optional<User> findByUsername(String username);
+    Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserNameOrEmailOrPhoneNumber(String userName, String email, String phoneNumber);
+
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/service/UserService.java
@@ -24,7 +24,6 @@ public class UserService {
 
         //회원 저장
         User user = new User(req, passwordEncoder.encode(req.getPassword()));
-        //todo: 시큐리티 도입 후 자동화 하도록 변경 (추후 삭제)
         user.create(req.getUserName());
         userRepository.save(user);
     }

--- a/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
@@ -1,23 +1,57 @@
 package com.sparta.vroomvroom.global.config;
 
+import com.sparta.vroomvroom.domain.user.repository.BlackListRepository;
+import com.sparta.vroomvroom.global.conmon.constants.UserRole;
+import com.sparta.vroomvroom.global.security.UserDetailsServiceImpl;
+import com.sparta.vroomvroom.global.security.filter.JwtFilter;
+import com.sparta.vroomvroom.global.security.filter.LoginFilter;
+import com.sparta.vroomvroom.global.utils.JwtUtil;
+import io.jsonwebtoken.Jwt;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final BlackListRepository blackListRepository;
+    private final AuthenticationConfiguration authenticationConfiguration;
     @Bean
     PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtFilter jwtFilter() {
+        JwtFilter filter = new JwtFilter(jwtUtil,blackListRepository,userDetailsService);
+        return filter;
+    }
+
+    @Bean
+    public LoginFilter loginFilter() throws Exception {
+        LoginFilter loginFilter = new LoginFilter(jwtUtil);
+        loginFilter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return loginFilter;
+    }
+
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,15 +63,20 @@ public class SecurityConfig {
                 // 인증 인가 규칙
                 // 임시로 전부 허용
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers("/api/v1/users/login","/api/v1/users/signup").permitAll()
+                        .requestMatchers("/api/v1/users/login/test").hasRole(UserRole.ROLE_MANAGER.getRole())
+                        .anyRequest().denyAll()
                 )
 
                 // 로그아웃 관련
                 .logout(logout -> logout
-                        .logoutUrl("/api/v1/logout")
+                        .logoutUrl("/api/v1/users/logout")
                         .deleteCookies("AToken")
                         .invalidateHttpSession(true)
                 );
+
+        http.addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterAt(loginFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
@@ -75,8 +75,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/users/login","/api/v1/users/signup").permitAll()
                         .requestMatchers("/api/v1/users/logout").authenticated()
-                        //Todo: PR 병합시 삭제
-                        .requestMatchers("/api/v1/users/login/test").authenticated()
                         .anyRequest().permitAll()
                 )
 

--- a/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
@@ -1,20 +1,23 @@
 package com.sparta.vroomvroom.global.config;
 
 import com.sparta.vroomvroom.domain.user.repository.BlackListRepository;
-import com.sparta.vroomvroom.global.conmon.constants.UserRole;
 import com.sparta.vroomvroom.global.security.UserDetailsServiceImpl;
 import com.sparta.vroomvroom.global.security.filter.JwtFilter;
+import com.sparta.vroomvroom.global.security.handler.CustomAccessDeniedHandler;
+import com.sparta.vroomvroom.global.security.handler.CustomAuthEntryPoint;
+import com.sparta.vroomvroom.global.security.handler.JwtLogoutHandler;
+import com.sparta.vroomvroom.global.security.handler.JwtLogoutSuccessHandler;
 import com.sparta.vroomvroom.global.security.filter.LoginFilter;
 import com.sparta.vroomvroom.global.utils.JwtUtil;
-import io.jsonwebtoken.Jwt;
+import com.sparta.vroomvroom.global.utils.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -23,12 +26,19 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final BlackListRepository blackListRepository;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final ResponseUtil responseUtil;
+    private final CustomAuthEntryPoint customAuthEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+
+
     @Bean
     PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -47,34 +57,44 @@ public class SecurityConfig {
 
     @Bean
     public LoginFilter loginFilter() throws Exception {
-        LoginFilter loginFilter = new LoginFilter(jwtUtil);
+        LoginFilter loginFilter = new LoginFilter(jwtUtil,responseUtil);
         loginFilter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         return loginFilter;
     }
 
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtLogoutHandler jwtLogoutHandler, JwtLogoutSuccessHandler jwtLogoutSuccessHandler) throws Exception {
         http
                 //보안 옵션
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
 
-                // 인증 인가 규칙
-                // 임시로 전부 허용
+                //인증 인가 규칙
+                //Todo: v1개발 진척도에 따라 세부 조정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/users/login","/api/v1/users/signup").permitAll()
-                        .requestMatchers("/api/v1/users/login/test").hasRole(UserRole.ROLE_MANAGER.getRole())
-                        .anyRequest().denyAll()
+                        .requestMatchers("/api/v1/users/logout").authenticated()
+                        //Todo: PR 병합시 삭제
+                        .requestMatchers("/api/v1/users/login/test").authenticated()
+                        .anyRequest().permitAll()
                 )
 
                 // 로그아웃 관련
                 .logout(logout -> logout
                         .logoutUrl("/api/v1/users/logout")
-                        .deleteCookies("AToken")
+                        .addLogoutHandler(jwtLogoutHandler)
+                        .logoutSuccessHandler(jwtLogoutSuccessHandler)
                         .invalidateHttpSession(true)
-                );
+                )
 
+                //시큐리티 단 통합 예외처리
+                .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(customAuthEntryPoint)
+                .accessDeniedHandler(customAccessDeniedHandler)
+        );
+
+        //필터 추가 및 교체
         http.addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
         http.addFilterAt(loginFilter(), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/sparta/vroomvroom/global/conmon/BaseEntity.java
+++ b/src/main/java/com/sparta/vroomvroom/global/conmon/BaseEntity.java
@@ -20,7 +20,7 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
 
     //시큐리티 적용 되어있어야 동작
-//    @CreatedBy
+    @CreatedBy
     @Column(name = "created_by",updatable = false, nullable = false, length = 20)
     private String createdBy;
 
@@ -28,7 +28,7 @@ public abstract class BaseEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-//    @LastModifiedBy
+    @LastModifiedBy
     @Column(name = "updated_by", length = 20)
     private String updatedBy;
 

--- a/src/main/java/com/sparta/vroomvroom/global/conmon/BaseResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/global/conmon/BaseResponse.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import static com.sparta.vroomvroom.global.conmon.constants.BaseResponseStatus.FAIL;
 import static com.sparta.vroomvroom.global.conmon.constants.BaseResponseStatus.SUCCESS;
 
-import com.sparta.vroomvroom.global.conmon.constants.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/vroomvroom/global/conmon/constants/UserRole.java
+++ b/src/main/java/com/sparta/vroomvroom/global/conmon/constants/UserRole.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum UserRole {
-    ROLE_CUSTOMER("CUSTOMER"),
-    ROLE_OWNER("OWNER"),
-    ROLE_MANAGER("MANAGER"),
-    ROLE_MASTER("MASTER");
+    ROLE_CUSTOMER("ROLE_CUSTOMER"),
+    ROLE_OWNER("ROLE_OWNER"),
+    ROLE_MANAGER("ROLE_MANAGER"),
+    ROLE_MASTER("ROLE_MASTER");
 
     private final String role;
 

--- a/src/main/java/com/sparta/vroomvroom/global/conmon/constants/UserRole.java
+++ b/src/main/java/com/sparta/vroomvroom/global/conmon/constants/UserRole.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum UserRole {
-    ROLE_CUSTOMER("ROLE_CUSTOMER"),
-    ROLE_OWNER("ROLE_OWNER"),
-    ROLE_MANAGER("ROLE_MANAGER"),
-    ROLE_MASTER("ROLE_MASTER");
+    ROLE_CUSTOMER("CUSTOMER"),
+    ROLE_OWNER("OWNER"),
+    ROLE_MANAGER("MANAGER"),
+    ROLE_MASTER("MASTER");
 
     private final String role;
 

--- a/src/main/java/com/sparta/vroomvroom/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.nio.file.AccessDeniedException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -21,6 +23,12 @@ public class GlobalExceptionHandler {
                 .get(0)
                 .getDefaultMessage(); // 첫 번째 에러 메시지 추출
         return new BaseResponse(errorMessage);
+    }
+
+    //권한 없음 예외
+    @ExceptionHandler(AccessDeniedException.class)
+    public BaseResponse handleAllExceptions(AccessDeniedException ex) {
+        return new BaseResponse("요청이 실패했습니다. 권한이 없습니다.");
     }
 
     // 나머지 예외

--- a/src/main/java/com/sparta/vroomvroom/global/security/AuditorAwareImpl.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/AuditorAwareImpl.java
@@ -8,10 +8,20 @@ import java.util.Optional;
 
 @Component
 public class AuditorAwareImpl implements AuditorAware<String> {
+
     @Override
     public Optional<String> getCurrentAuditor() {
         // JpaAuditing의 CreatedBy LastModifiedBy등 사용할때 여기서 값 가져오라고 명시
         // 시큐리티 컨텍스트에서 로그인한 사용자 ID 반환
-        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication().getName());
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .map(auth -> {
+                    Object principal = auth.getPrincipal();
+                    if (principal instanceof UserDetailsImpl userDetails) {
+                        return userDetails.getUser().getUserName();
+                    }
+
+                    return null;
+                });
     }
+
 }

--- a/src/main/java/com/sparta/vroomvroom/global/security/AuditorAwareImpl.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/AuditorAwareImpl.java
@@ -1,17 +1,17 @@
-//package com.sparta.vroomvroom.global.security;
-//
-//import org.springframework.data.domain.AuditorAware;
-//import org.springframework.security.core.context.SecurityContextHolder;
-//import org.springframework.stereotype.Component;
-//
-//import java.util.Optional;
-//
-//@Component
-//public class AuditorAwareImpl implements AuditorAware<String> {
-//    @Override
-//    public Optional<String> getCurrentAuditor() {
-//        // JpaAuditing의 CreatedBy LastModifiedBy등 사용할때 여기서 값 가져오라고 명시
-//        // 시큐리티 컨텍스트에서 로그인한 사용자 ID 반환
-//        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication().getName());
-//    }
-//}
+package com.sparta.vroomvroom.global.security;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        // JpaAuditing의 CreatedBy LastModifiedBy등 사용할때 여기서 값 가져오라고 명시
+        // 시큐리티 컨텍스트에서 로그인한 사용자 ID 반환
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication().getName());
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsImpl.java
@@ -2,6 +2,7 @@ package com.sparta.vroomvroom.global.security;
 
 import com.sparta.vroomvroom.domain.user.model.entity.User;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -21,7 +22,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return List.of(new SimpleGrantedAuthority(user.getRole().getRole()));
     }
 
     @Override

--- a/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsImpl.java
@@ -1,0 +1,36 @@
+package com.sparta.vroomvroom.global.security;
+
+import com.sparta.vroomvroom.domain.user.model.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserName();
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsServiceImpl.java
@@ -15,7 +15,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
+        User user = userRepository.findByUserName(username)
                 .orElseThrow(() -> new UsernameNotFoundException("입력한 정보와 일치하는 회원이 없습니다."));
 
         return new UserDetailsImpl(user);

--- a/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/UserDetailsServiceImpl.java
@@ -1,0 +1,23 @@
+package com.sparta.vroomvroom.global.security;
+
+import com.sparta.vroomvroom.domain.user.model.entity.User;
+import com.sparta.vroomvroom.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("입력한 정보와 일치하는 회원이 없습니다."));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/filter/JwtFilter.java
@@ -1,0 +1,26 @@
+package com.sparta.vroomvroom.global.security.filter;
+
+import com.sparta.vroomvroom.domain.user.repository.UserRepository;
+import com.sparta.vroomvroom.global.utils.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/filter/JwtFilter.java
@@ -2,25 +2,76 @@ package com.sparta.vroomvroom.global.security.filter;
 
 import com.sparta.vroomvroom.domain.user.repository.UserRepository;
 import com.sparta.vroomvroom.global.utils.JwtUtil;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j(topic = "JWT Filter")
 @Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    UserRepository userRepository;
+    private final UserRepository userRepository;
+    private final UserDetailsService userDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+        //토큰 추출
+        String token = jwtUtil.getTokenFromCookie(request);
+
+        //토큰 검증
+        if(token == null || !jwtUtil.validateToken(token)) {
+            log.warn("JWT 토큰이 존재하지 않거나 유효하지 않습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+        //토큰에서 값 추출
+        Claims claims = jwtUtil.getUserInfoFromToken(token);
+        String userName = claims.get("userName", String.class);
+
+        //인증 시도
+        try {
+            //성공시 인증객체 생성
+            setAuthentication(userName);
+        } catch (Exception e) {
+            //실패시 로그
+            log.error("JWT 토큰을 통한 인증이 실패했습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //정상 인증이 끝나면 다음 필터 진행
+        filterChain.doFilter(request, response);
+    }
+
+    // 인증 처리
+    public void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/global/security/filter/JwtLogoutHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/filter/JwtLogoutHandler.java
@@ -1,0 +1,39 @@
+package com.sparta.vroomvroom.global.security.filter;
+
+import com.sparta.vroomvroom.domain.user.model.entity.BlackList;
+import com.sparta.vroomvroom.domain.user.repository.BlackListRepository;
+import com.sparta.vroomvroom.global.utils.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtLogoutHandler implements LogoutHandler {
+
+    private final BlackListRepository blackListRepository;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        String token = jwtUtil.getTokenFromCookie(request);
+        if(token != null && jwtUtil.validateToken(token)) {
+            // 블랙리스트에 없는 경우에만 등록
+            if (!blackListRepository.findByToken(token).isPresent()) {
+                BlackList blackList = new BlackList(token);
+                blackListRepository.save(blackList);
+            }
+
+            // 쿠키 삭제
+            Cookie cookie = new Cookie("AToken", null);
+            cookie.setPath("/");
+            cookie.setHttpOnly(true);
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+        }
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/filter/LoginFilter.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/filter/LoginFilter.java
@@ -1,4 +1,92 @@
 package com.sparta.vroomvroom.global.security.filter;
 
-public class LoginFilter {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.vroomvroom.domain.user.model.dto.request.UserLoginRequest;
+import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import com.sparta.vroomvroom.global.conmon.constants.UserRole;
+import com.sparta.vroomvroom.global.security.UserDetailsImpl;
+import com.sparta.vroomvroom.global.utils.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "Login Filter")
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+    public LoginFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        setFilterProcessesUrl("/api/v1/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        // 토큰이 있는 상태로 로그인 시도시 에러 응답
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated()) {
+            sendResponse(response,"잘못된 접근 입니다. 이미 인증된 사용자입니다.", HttpServletResponse.SC_BAD_REQUEST);
+            return null;
+        }
+        try {
+            UserLoginRequest userLoginRequest = new ObjectMapper().readValue(request.getInputStream(), UserLoginRequest.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            userLoginRequest.getUserName(),
+                            userLoginRequest.getPassword(),
+                            null
+                    )
+            );
+        } catch (IOException e) {
+            sendResponse(response,"인증에 실패했습니다. 입력한 정보를 확인해주세요.",HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }
+    }
+
+    @Override
+    //성공시 쿠키에 토큰 세팅
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+        UserRole role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+        Cookie cookie = jwtUtil.createToken(username, role);
+        response.addCookie(cookie);
+        //규격에 맞게 응답
+        sendResponse(response,"", HttpServletResponse.SC_OK);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        //규격에 맞게 응답
+        sendResponse(response,"인증에 실패했습니다. 입력한 정보를 확인해주세요.", HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    protected void sendResponse(HttpServletResponse response,String message, int responseStatus) {
+        //호출시 넘겨준 응답코드가 200이 아니면 에러 메시지 응답, 200이면 성공 메시지 응답
+        try {
+            response.setStatus(responseStatus);
+            response.setContentType("application/json;charset=UTF-8");
+
+            //기본 = 성공 응답
+            BaseResponse baseResponse = new BaseResponse();
+            if(responseStatus != HttpServletResponse.SC_OK){
+                baseResponse = new BaseResponse<>(message);
+            }
+
+            String json = new ObjectMapper().writeValueAsString(baseResponse);
+
+            response.getWriter().write(json);
+            response.getWriter().flush();
+        } catch (IOException ioException) {
+            log.error("응답 전송 실패", ioException);
+        }
+    }
 }

--- a/src/main/java/com/sparta/vroomvroom/global/security/filter/LoginFilter.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/filter/LoginFilter.java
@@ -1,0 +1,4 @@
+package com.sparta.vroomvroom.global.security.filter;
+
+public class LoginFilter {
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package com.sparta.vroomvroom.global.security.handler;
+
+import com.sparta.vroomvroom.global.utils.ResponseUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+//인증은 성공했지만 시큐리티 단에서 URI매핑 등 권한으로 인해 실패할 경우 처리 핸들러
+//로그인 성공 이후 권한이 부족할 경우 처리
+//requestMatcher에서 hasRole()등 권한 처리가 실패하면 동작
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ResponseUtil responseUtil;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        responseUtil.sendErrorResponse(response, "요청이 실패했습니다. 접근 권한이 없습니다.", HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/handler/CustomAuthEntryPoint.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/handler/CustomAuthEntryPoint.java
@@ -1,0 +1,28 @@
+package com.sparta.vroomvroom.global.security.handler;
+
+import com.sparta.vroomvroom.global.utils.ResponseUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+//스프링 시큐리티 단에서 인증 실패시 응답 처리 핸들러
+//토큰이 없거나, 만료되거나, 위조된 경우 처리
+//requestMatcher에서 authenticated()를 통과하지 못하면 동작
+public class CustomAuthEntryPoint implements AuthenticationEntryPoint {
+
+    private final ResponseUtil responseUtil;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        responseUtil.sendErrorResponse(response, "요청이 실패했습니다. 인증되지 않은 사용자입니다.",HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutHandler.java
@@ -22,6 +22,8 @@ public class JwtLogoutHandler implements LogoutHandler {
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         String token = jwtUtil.getTokenFromCookie(request);
         if(token != null && jwtUtil.validateToken(token)) {
+            //Todo: 블랙리스트 조회로 DB I/O가 과도하게 발생중 개선 필요
+
             // 블랙리스트에 없는 경우에만 등록
             if (!blackListRepository.findByToken(token).isPresent()) {
                 BlackList blackList = new BlackList(token);

--- a/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutHandler.java
@@ -1,4 +1,4 @@
-package com.sparta.vroomvroom.global.security.filter;
+package com.sparta.vroomvroom.global.security.handler;
 
 import com.sparta.vroomvroom.domain.user.model.entity.BlackList;
 import com.sparta.vroomvroom.domain.user.repository.BlackListRepository;
@@ -36,6 +36,10 @@ public class JwtLogoutHandler implements LogoutHandler {
             cookie.setHttpOnly(true);
             cookie.setMaxAge(0);
             response.addCookie(cookie);
+        }else{
+            //로그아웃은 예외 발생이 아니면 무조건 성공 핸들러 요청
+            //응답 구분은 성공 핸들러에서 처리
+            request.setAttribute("logoutError", "잘못된 접근입니다. 로그인 되어 있지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutSuccessHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutSuccessHandler.java
@@ -1,0 +1,26 @@
+package com.sparta.vroomvroom.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+//logout성공 시 자동으로 /login이나 다른 url로 리다이렉트를 방지하는 핸들러
+//logout성공을 감지해서 가로챔
+public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+                                Authentication authentication) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+        BaseResponse baseResponse = new BaseResponse<>();
+        response.getWriter().write(new ObjectMapper().writeValueAsString(baseResponse));
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutSuccessHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutSuccessHandler.java
@@ -1,7 +1,5 @@
 package com.sparta.vroomvroom.global.security.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.vroomvroom.global.conmon.BaseResponse;
 import com.sparta.vroomvroom.global.utils.ResponseUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutSuccessHandler.java
+++ b/src/main/java/com/sparta/vroomvroom/global/security/handler/JwtLogoutSuccessHandler.java
@@ -1,9 +1,11 @@
-package com.sparta.vroomvroom.global.security.filter;
+package com.sparta.vroomvroom.global.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import com.sparta.vroomvroom.global.utils.ResponseUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -11,16 +13,22 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 //logout성공 시 자동으로 /login이나 다른 url로 리다이렉트를 방지하는 핸들러
 //logout성공을 감지해서 가로챔
 public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final ResponseUtil responseUtil;
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
                                 Authentication authentication) throws IOException {
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType("application/json;charset=UTF-8");
-        BaseResponse baseResponse = new BaseResponse<>();
-        response.getWriter().write(new ObjectMapper().writeValueAsString(baseResponse));
-        response.getWriter().flush();
+        Object errorMessage = request.getAttribute("logoutError");
+        if (errorMessage != null) {
+            // 쿠키 없거나 비정상 접근
+            responseUtil.sendErrorResponse(response, errorMessage.toString(), HttpServletResponse.SC_BAD_REQUEST);
+        } else {
+            // 정상 로그아웃
+            responseUtil.sendSuccessResponse(response);
+        }
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
+++ b/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
@@ -1,0 +1,95 @@
+package com.sparta.vroomvroom.global.utils;
+
+import com.sparta.vroomvroom.global.conmon.constants.UserRole;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+
+    private static final String AUTHORIZATION_KEY = "role";
+    private static final String USER_ID_KEY = "userId";
+    private static final String COOKIE_NAME = "AToken";
+
+    @Value("${jwt.access-expiration}")
+    private long TOKEN_TIME;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public Cookie createToken(String username, UserRole role) {
+        Date now = new Date();
+
+        String token = Jwts.builder()
+                .setSubject(username)
+                .claim(AUTHORIZATION_KEY, role.name())
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + TOKEN_TIME))
+                .signWith(key, signatureAlgorithm)
+                .compact();
+
+        Cookie cookie = new Cookie(COOKIE_NAME, token);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        return cookie;
+    }
+
+    //쿠키에서 jwt 추출
+    public String getTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if (COOKIE_NAME.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    //토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    //클레임 추출
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    //userId 바로 추출
+    public Long getUserIdFromToken(String token) {
+        Claims claims = getUserInfoFromToken(token);
+        return claims.get(USER_ID_KEY, Long.class);
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
+++ b/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
@@ -18,8 +19,6 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-    private static final String AUTHORIZATION_KEY = "role";
-    private static final String USER_ID_KEY = "userId";
     private static final String COOKIE_NAME = "AToken";
 
     @Value("${jwt.access-expiration}")
@@ -32,8 +31,8 @@ public class JwtUtil {
 
     @PostConstruct
     public void init() {
-        byte[] bytes = Base64.getDecoder().decode(secretKey);
-        key = Keys.hmacShaKeyFor(bytes);
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        key = Keys.hmacShaKeyFor(keyBytes);
     }
 
     public Cookie createToken(String username, UserRole role) {
@@ -41,7 +40,6 @@ public class JwtUtil {
 
         String token = Jwts.builder()
                 .setSubject(username)
-                .claim(AUTHORIZATION_KEY, role.name())
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + TOKEN_TIME))
                 .signWith(key, signatureAlgorithm)

--- a/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
+++ b/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
@@ -86,10 +86,4 @@ public class JwtUtil {
     public Claims getUserInfoFromToken(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }
-
-    //userId 바로 추출
-    public Long getUserIdFromToken(String token) {
-        Claims claims = getUserInfoFromToken(token);
-        return claims.get(USER_ID_KEY, Long.class);
-    }
 }

--- a/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
+++ b/src/main/java/com/sparta/vroomvroom/global/utils/JwtUtil.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.Base64;
 import java.util.Date;
 
 @Slf4j(topic = "JwtUtil")

--- a/src/main/java/com/sparta/vroomvroom/global/utils/ResponseUtil.java
+++ b/src/main/java/com/sparta/vroomvroom/global/utils/ResponseUtil.java
@@ -1,0 +1,50 @@
+package com.sparta.vroomvroom.global.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j(topic = "response")
+@Component
+public class ResponseUtil {
+
+    public void sendErrorResponse(HttpServletResponse response, String message, int responseStatus) {
+        //호출시 넘겨준 응답코드가 200이 아니면 에러 메시지 응답, 200이면 성공 메시지 응답
+        try {
+            response.setStatus(responseStatus);
+            response.setContentType("application/json;charset=UTF-8");
+
+            BaseResponse baseResponse = new BaseResponse<>(message);
+
+
+            String json = new ObjectMapper().writeValueAsString(baseResponse);
+
+            response.getWriter().write(json);
+            response.getWriter().flush();
+        } catch (IOException ioException) {
+            log.error("응답 전송 실패", ioException);
+        }
+    }
+
+    public void sendSuccessResponse(HttpServletResponse response) {
+        //호출시 넘겨준 응답코드가 200이 아니면 에러 메시지 응답, 200이면 성공 메시지 응답
+        try {
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType("application/json;charset=UTF-8");
+
+            //기본 = 성공 응답
+            BaseResponse baseResponse = new BaseResponse();
+
+            String json = new ObjectMapper().writeValueAsString(baseResponse);
+
+            response.getWriter().write(json);
+            response.getWriter().flush();
+        } catch (IOException ioException) {
+            log.error("응답 전송 실패", ioException);
+        }
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/global/utils/ResponseUtil.java
+++ b/src/main/java/com/sparta/vroomvroom/global/utils/ResponseUtil.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 public class ResponseUtil {
 
     public void sendErrorResponse(HttpServletResponse response, String message, int responseStatus) {
-        //호출시 넘겨준 응답코드가 200이 아니면 에러 메시지 응답, 200이면 성공 메시지 응답
         try {
             response.setStatus(responseStatus);
             response.setContentType("application/json;charset=UTF-8");
@@ -31,7 +30,6 @@ public class ResponseUtil {
     }
 
     public void sendSuccessResponse(HttpServletResponse response) {
-        //호출시 넘겨준 응답코드가 200이 아니면 에러 메시지 응답, 200이면 성공 메시지 응답
         try {
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentType("application/json;charset=UTF-8");


### PR DESCRIPTION
### 연관된 이슈
#2  

### 변경사항

- 로그인 관련 Dto 및 서비스 클래스 작성
- JWT 토큰을 검증하여 인증하는 Jwt필터 구현
- 로그인시 동작하여 정상 인증되면 토큰을 쿠키형태로 발급하는 LoginFilter 구현
- Security 관련 예외를 처리하도록 전용 핸들러 추가 및 GlobalExceptionHandler에 처리함수 추가
- 로그아웃을 위한 전용 핸들러 구현
- 시큐리티 단에서 BaseResponse 응답에 사용할 ResponseUtil 클래스 구현
- 시큐리티 동작 테스트를 위한 임시 엔드포인트 구현(삭제필요)
- 동작 테스트 가능하도록 SecurityConfig작성(수정필요)
- CreatedBy와 같은 Auditing 동작하도록 설계(테스트 어려움 - 추후에 확인 후 로직 수정 필요)

### 리뷰요청
> 요청은 https://web.postman.co/workspace/My-Workspace~45a5781c-81fa-4d3c-8dcc-fca9960c711c/collection/35982623-d2b969f9-0927-4b0e-be66-1793193351fa?action=share&source=copy-link&creator=35982623 사용 (안될 시 API명세서 참조)

- 회원가입 (회원가입은 토큰과 무관해야함)
  - 토큰없이 회원가입이 잘 되는지

- 로그인 (로그인은 로그아웃된 상태에서만 가능해야함)
  - 가입한 회원으로 로그인이 성공해서 쿠키 세팅이 되는지
  - 토큰이 유효한 상태에서 로그인을 시도하면 잘못된 접근 처리가 되는지 
  
- 로그아웃 (로그아웃은 정상적으로 로그인이 유지 된 상태에서만 가능해야함)
  - 토큰이 유효할 때 로그아웃이 잘 되는지 
  - 토큰이 없는 상태에서 로그아웃을 시도하면 잘못된 접근 처리가 되는지 
  - 로그아웃 시 블랙리스트에 등록되는지

- 권한 및 특수상황 (test URI는 CUSTOMER, MANAGER만 호출 가능해야함)
  - GET /api/v1/users/login/test에 CUSTOMER, MANAGER만 접근이 가능한지 (콘솔에 print문이 찍히는지)
  - 토큰 없이 GET /api/v1/users/login/test에 요청했을시 미인증 처리가 되는지
  - 유효하지 않은 토큰으로는 어떤 요청을 해도 블랙리스트에 잘 등록되는지 (환경변수로 만료시간 짧게 설정 5000정도 - 1000당 1초)
  - 이외에도 발생할 수 있는 경우의 수를 전부 처리 가능한지 (SecurityConfig 매핑규칙 자유롭게 변경하면서)
  
- 코드
  - 불필요한 부분과 로직에 어긋나는 부분이 있는지
  - 가독성과 재사용성이 고려됐는지
  - 불필요하게 반복되는 코드를 줄일 수 있는지