### PR TITLE
[feat] 장바구니 CRUD 구현

### DIFF
--- a/src/main/java/com/sparta/vroomvroom/domain/cart/controller/CartController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/controller/CartController.java
@@ -1,13 +1,72 @@
 package com.sparta.vroomvroom.domain.cart.controller;
 
+import com.sparta.vroomvroom.domain.cart.model.dto.request.AddCartMenuRequest;
+import com.sparta.vroomvroom.domain.cart.model.dto.request.UpdateCartMenuRequest;
+import com.sparta.vroomvroom.domain.cart.model.dto.response.CartResponse;
 import com.sparta.vroomvroom.domain.cart.service.CartService;
+import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import com.sparta.vroomvroom.global.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class CartController {
     private final CartService cartService;
+
+    @GetMapping("/carts")
+    public BaseResponse<CartResponse> getCart(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        CartResponse response = cartService.getCart(userDetails.getUser().getUserId());
+        return new BaseResponse<>(response);
+    }
+
+    @PostMapping("/carts")
+    public BaseResponse<Void> createCartMenu(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody AddCartMenuRequest request
+    ) {
+        cartService.createCartMenu(userDetails.getUser().getUserId(), request);
+        return new BaseResponse<>();
+    }
+
+    @PatchMapping("/carts/{cartMenuId}")
+    public BaseResponse<Void> updateCartMenu(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID cartMenuId,
+            @Valid @RequestBody UpdateCartMenuRequest request
+    ) {
+        cartService.updateCartMenu(
+                userDetails.getUser().getUserId(),
+                cartMenuId,
+                request
+        );
+        return new BaseResponse<>();
+    }
+
+    @DeleteMapping("/carts/{cartMenuId}")
+    public BaseResponse<Void> deleteCartMenu(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID cartMenuId
+    ) {
+        cartService.deleteCartMenu(
+                userDetails.getUser().getUserId(),
+                cartMenuId
+        );
+        return new BaseResponse<>();
+    }
+
+    @DeleteMapping("/carts")
+    public BaseResponse<Void> clearCart(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        cartService.clearCart(userDetails.getUser().getUserId());
+        return new BaseResponse<>();
+    }
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/request/AddCartMenuRequest.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/request/AddCartMenuRequest.java
@@ -1,0 +1,21 @@
+// AddCartMenuRequest.java
+package com.sparta.vroomvroom.domain.cart.model.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class AddCartMenuRequest {
+
+    @NotNull(message = "메뉴 ID는 필수입니다.")
+    private UUID menuId;
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    private Integer menuAmount;
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/request/UpdateCartMenuRequest.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/request/UpdateCartMenuRequest.java
@@ -1,0 +1,15 @@
+package com.sparta.vroomvroom.domain.cart.model.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateCartMenuRequest {
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 0, message = "수량은 0개 이상이어야 합니다.")
+    private Integer menuAmount;
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/response/CartMenuResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/response/CartMenuResponse.java
@@ -1,0 +1,20 @@
+package com.sparta.vroomvroom.domain.cart.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class CartMenuResponse {
+
+    private UUID cartMenuId;
+    private UUID menuId;
+    private String menuName;
+    private Integer menuPrice;
+    private Integer menuAmount;
+    private String menuImage;
+    private UUID companyId;
+    private String companyName;
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/response/CartResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/model/dto/response/CartResponse.java
@@ -1,0 +1,17 @@
+package com.sparta.vroomvroom.domain.cart.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class CartResponse {
+
+    private UUID cartId;
+    private Boolean isEmpty;
+    private Integer totalPrice;
+    private List<CartMenuResponse> cartMenus;
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/model/entity/Cart.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/model/entity/Cart.java
@@ -5,14 +5,12 @@ import com.sparta.vroomvroom.global.conmon.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "carts")
 @Getter
-@Setter
 @NoArgsConstructor
 public class Cart extends BaseEntity {
 
@@ -27,5 +25,27 @@ public class Cart extends BaseEntity {
 
     @Column(name = "is_empty", nullable = false)
     private boolean isEmpty = true;
+
+    // 생성 메서드
+    public static Cart createCart(User user) {
+        Cart cart = new Cart();
+        cart.user = user;
+        cart.isEmpty = true;
+        cart.create(user.getUserName());
+        return cart;
+    }
+
+    // 비즈니스 로직 메서드
+    public void markAsNotEmpty() {
+        this.isEmpty = false;
+    }
+
+    public void markAsEmpty() {
+        this.isEmpty = true;
+    }
+
+    public void updateEmptyStatus(boolean hasItems) {
+        this.isEmpty = !hasItems;
+    }
 
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/model/entity/CartMenu.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/model/entity/CartMenu.java
@@ -4,7 +4,6 @@ import com.sparta.vroomvroom.domain.menu.model.entity.Menu;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
@@ -13,7 +12,6 @@ import java.util.UUID;
 @Entity
 @Table(name = "cart_menus")
 @Getter
-@Setter
 @NoArgsConstructor
 public class CartMenu {
 
@@ -37,11 +35,32 @@ public class CartMenu {
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    //    @CreatedBy
     @Column(name = "created_by",updatable = false, nullable = false, length = 20)
     private String createdBy;
 
-    public void create(String userName){
-        this.createdBy = userName;
+    // 생성 메서드
+    public static CartMenu createCartMenu(Cart cart, Menu menu, int menuAmount, String userName) {
+        CartMenu cartMenu = new CartMenu();
+        cartMenu.cart = cart;
+        cartMenu.menu = menu;
+        cartMenu.menuAmount = menuAmount;
+        cartMenu.createdAt = LocalDateTime.now();
+        cartMenu.createdBy = userName;
+        return cartMenu;
+    }
+
+    public void increaseAmount(int amount) {
+        this.menuAmount += amount;
+    }
+
+    public void updateAmount(int newAmount) {
+        if (newAmount < 0) {
+            throw new IllegalArgumentException("수량은 0 이상이어야 합니다.");
+        }
+        this.menuAmount = newAmount;
+    }
+
+    public boolean isSameCart(UUID cartId) {
+        return this.cart.getCartId().equals(cartId);
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/repository/CartMenuRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/repository/CartMenuRepository.java
@@ -1,10 +1,17 @@
 package com.sparta.vroomvroom.domain.cart.repository;
 
-import com.sparta.vroomvroom.domain.cart.model.entity.Cart;
 import com.sparta.vroomvroom.domain.cart.model.entity.CartMenu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CartMenuRepository extends JpaRepository<CartMenu, UUID> {
+
+    List<CartMenu> findByCart_CartId(UUID cartId);
+
+    Optional<CartMenu> findByCart_CartIdAndMenu_MenuId(UUID cartId, UUID menuId);
+
+    boolean existsByCart_CartId(UUID cartId);
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/repository/CartRepository.java
@@ -3,7 +3,10 @@ package com.sparta.vroomvroom.domain.cart.repository;
 import com.sparta.vroomvroom.domain.cart.model.entity.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CartRepository extends JpaRepository<Cart, UUID> {
+
+    Optional<Cart> findByUser_UserId(Long userId);
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/service/CartService.java
@@ -1,11 +1,293 @@
 package com.sparta.vroomvroom.domain.cart.service;
 
+import com.sparta.vroomvroom.domain.cart.model.dto.request.AddCartMenuRequest;
+import com.sparta.vroomvroom.domain.cart.model.dto.request.UpdateCartMenuRequest;
+import com.sparta.vroomvroom.domain.cart.model.dto.response.CartMenuResponse;
+import com.sparta.vroomvroom.domain.cart.model.dto.response.CartResponse;
+import com.sparta.vroomvroom.domain.cart.model.entity.Cart;
+import com.sparta.vroomvroom.domain.cart.model.entity.CartMenu;
+import com.sparta.vroomvroom.domain.cart.repository.CartMenuRepository;
 import com.sparta.vroomvroom.domain.cart.repository.CartRepository;
+import com.sparta.vroomvroom.domain.company.model.entity.Company;
+import com.sparta.vroomvroom.domain.company.repository.CompanyRepository;
+import com.sparta.vroomvroom.domain.menu.model.entity.Menu;
+import com.sparta.vroomvroom.domain.menu.repository.MenuRepository;
+import com.sparta.vroomvroom.domain.user.model.entity.User;
+import com.sparta.vroomvroom.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class CartService {
     private final CartRepository cartRepository;
+    private final CartMenuRepository cartMenuRepository;
+    private final MenuRepository menuRepository;
+    private final UserRepository userRepository;
+    private final CompanyRepository companyRepository;
+
+    @Transactional
+    public CartResponse getCart(Long userId) {
+        Cart cart = getOrCreateCart(userId);
+        List<CartMenu> cartMenus = cartMenuRepository.findByCart_CartId(cart.getCartId());
+
+        return buildCartResponse(cart, cartMenus);
+    }
+
+    @Transactional
+    public void createCartMenu(Long userId, AddCartMenuRequest request) {
+        Cart cart = getOrCreateCart(userId);
+        Menu menu = menuRepository.findById(request.getMenuId())
+                .orElseThrow(() -> new IllegalArgumentException("메뉴를 찾을 수 없습니다."));
+
+        // 장바구니에 이미 다른 가게의 메뉴가 있는지 확인
+        List<CartMenu> existingCartMenus = cartMenuRepository.findByCart_CartId(cart.getCartId());
+        if (!existingCartMenus.isEmpty()) {
+            UUID existingCompanyId = existingCartMenus.get(0).getMenu().getCompanyId();
+            if (!existingCompanyId.equals(menu.getCompanyId())) {
+                throw new IllegalArgumentException("다른 가게의 메뉴는 함께 담을 수 없습니다. 장바구니를 비운 후 다시 시도해주세요.");
+            }
+        }
+
+        // 이미 장바구니에 같은 메뉴가 있으면 수량 증가
+        Optional<CartMenu> existingCartMenu = cartMenuRepository.findByCart_CartIdAndMenu_MenuId(
+                cart.getCartId(), request.getMenuId());
+
+        if (existingCartMenu.isPresent()) {
+            CartMenu cartMenu = existingCartMenu.get();
+            cartMenu.increaseAmount(request.getMenuAmount());
+            cartMenuRepository.save(cartMenu);
+        } else {
+            CartMenu newCartMenu = CartMenu.createCartMenu(
+                    cart,
+                    menu,
+                    request.getMenuAmount(),
+                    cart.getUser().getUserName()
+            );
+            cartMenuRepository.save(newCartMenu);
+        }
+
+        // 장바구니 상태 업데이트
+        cart.markAsNotEmpty();
+        cartRepository.save(cart);
+    }
+
+    @Transactional
+    public void updateCartMenu(Long userId, UUID cartMenuId, UpdateCartMenuRequest request) {
+        Cart cart = getOrCreateCart(userId);
+        CartMenu cartMenu = cartMenuRepository.findById(cartMenuId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니 메뉴를 찾을 수 없습니다."));
+
+        // 권한 확인
+        if (!cartMenu.isSameCart(cart.getCartId())) {
+            throw new IllegalArgumentException("해당 장바구니 메뉴에 대한 권한이 없습니다.");
+        }
+
+        // 수량이 0이면 삭제
+        if (request.getMenuAmount() == 0) {
+            cartMenuRepository.delete(cartMenu);
+        } else {
+            cartMenu.updateAmount(request.getMenuAmount());
+            cartMenuRepository.save(cartMenu);
+        }
+
+        // 장바구니 상태 업데이트
+        boolean hasItems = cartMenuRepository.existsByCart_CartId(cart.getCartId());
+        cart.updateEmptyStatus(hasItems);
+        cartRepository.save(cart);
+    }
+
+    @Transactional
+    public void deleteCartMenu(Long userId, UUID cartMenuId) {
+        Cart cart = getOrCreateCart(userId);
+        CartMenu cartMenu = cartMenuRepository.findById(cartMenuId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니 메뉴를 찾을 수 없습니다."));
+
+        // 권한 확인
+        if (!cartMenu.isSameCart(cart.getCartId())) {
+            throw new IllegalArgumentException("해당 장바구니 메뉴에 대한 권한이 없습니다.");
+        }
+
+        cartMenuRepository.delete(cartMenu);
+
+        // 장바구니 상태 업데이트
+        boolean hasItems = cartMenuRepository.existsByCart_CartId(cart.getCartId());
+        cart.updateEmptyStatus(hasItems);
+        cartRepository.save(cart);
+    }
+
+    @Transactional
+    public void clearCart(Long userId) {
+        Cart cart = getOrCreateCart(userId);
+        List<CartMenu> cartMenus = cartMenuRepository.findByCart_CartId(cart.getCartId());
+
+        cartMenuRepository.deleteAll(cartMenus);
+
+        cart.markAsEmpty();
+        cartRepository.save(cart);
+    }
+
+
+    // 유저의 장바구니 조회 또는 생성
+    private Cart getOrCreateCart(Long userId) {
+        return cartRepository.findByUser_UserId(userId)
+                .orElseGet(() -> {
+                    User user = userRepository.findById(userId)
+                            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+                    Cart newCart = Cart.createCart(user);
+                    return cartRepository.save(newCart);
+                });
+    }
+
+    private CartResponse buildCartResponse(Cart cart, List<CartMenu> cartMenus) {
+        int totalPrice = 0;
+        List<CartMenuResponse> cartMenuResponses = new ArrayList<>();
+
+        for (CartMenu cartMenu : cartMenus) {
+            Menu menu = cartMenu.getMenu();
+
+            Company company = companyRepository.findById(menu.getCompanyId())
+                    .orElseThrow(() -> new IllegalArgumentException("업체를 찾을 수 없습니다."));
+
+            totalPrice += menu.getPrice() * cartMenu.getMenuAmount();
+
+            CartMenuResponse menuResponse = new CartMenuResponse(
+                    cartMenu.getCartMenuId(),
+                    menu.getMenuId(),
+                    menu.getName(),
+                    menu.getPrice(),
+                    cartMenu.getMenuAmount(),
+                    menu.getMenuImage(),
+                    company.getCompanyId(),
+                    company.getCompanyName()
+            );
+            cartMenuResponses.add(menuResponse);
+        }
+
+        return new CartResponse(
+                cart.getCartId(),
+                cart.isEmpty(),
+                totalPrice,
+                cartMenuResponses
+        );
+    }
 }
+
+/*
+    TODO: Menu 도메인 개발 완료 후 아래 테스트 데이터 삭제
+    -- 1. CompanyCategory 테스트 데이터
+    INSERT INTO company_categories (
+        company_category_id,
+        company_category_name,
+        created_at,
+        created_by,
+        is_deleted
+    ) VALUES (
+                 '00000000-0000-0000-0000-000000000200',
+                 '치킨',
+                 NOW(),
+                 'system',
+                 false
+             )
+    ON CONFLICT (company_category_id) DO NOTHING;
+
+    -- 2. Company 테스트 데이터
+    INSERT INTO companies (
+        company_id,
+        company_category_id,
+        company_name,
+        company_logo_url,
+        company_description,
+        phone_number,
+        delivery_fee,
+        delivery_radius,
+        owner_name,
+        biz_reg_no,
+        address,
+        detail_address,
+        zip_code,
+        created_at,
+        created_by,
+        is_deleted
+    ) VALUES (
+                 '00000000-0000-0000-0000-000000000100',
+                 '00000000-0000-0000-0000-000000000200',
+                 '테스트 치킨집',
+                 'http://example.com/logo.png',
+                 '맛있는 치킨집',
+                 '02-1234-5678',
+                 3000,
+                 5000,
+                 '홍길동',
+                 '123-45-67890',
+                 '서울시 강남구',
+                 '테헤란로 123',
+                 '06000',
+                 NOW(),
+                 'system',
+                 false
+             )
+    ON CONFLICT (company_id) DO NOTHING;
+
+    -- 3. Menu 테스트 데이터 (3개)
+    INSERT INTO menus (
+        menu_id,
+        company_id,
+        name,
+        price,
+        menu_group,
+        menu_image,
+        menu_description,
+        menu_status,
+        is_visible,
+        created_at,
+        created_by
+    ) VALUES
+          (
+              '00000000-0000-0000-0000-000000000001',
+              '00000000-0000-0000-0000-000000000100',
+              '후라이드 치킨',
+              18000,
+              '메인',
+              'https://example.com/fried-chicken.jpg',
+              '바삭한 후라이드 치킨',
+              'AVAILABLE',
+              true,
+              NOW(),
+              'system'
+          ),
+          (
+              '00000000-0000-0000-0000-000000000002',
+              '00000000-0000-0000-0000-000000000101',
+              '양념 치킨',
+              19000,
+              '메인',
+              'https://example.com/yangnyeom-chicken.jpg',
+              '달콤한 양념 치킨',
+              'AVAILABLE',
+              true,
+              NOW(),
+              'system'
+          ),
+          (
+              '00000000-0000-0000-0000-000000000003',
+              '00000000-0000-0000-0000-000000000101',
+              '콜라',
+              2000,
+              '사이드',
+              'https://example.com/cola.jpg',
+              '시원한 콜라',
+              'AVAILABLE',
+              true,
+              NOW(),
+              'system'
+          )
+    ON CONFLICT (menu_id) DO NOTHING;
+ */


### PR DESCRIPTION
### 연관된 이슈
#5

### 변경사항
* 장바구니 CRUD 관련 Entity 편의 메서드 추가
* 장바구니 Request/Response DTO 작성
* CartRepository, CartMenuRepository 쿼리 메서드 추가
* 장바구니 비즈니스 로직 구현 (Service)
  - 장바구니 조회/자동 생성
  - 메뉴 추가 (중복 시 수량 증가, 같은 가게만 담기 검증)
  - 수량 수정 (0이면 자동 삭제, 권한 확인)
  - 메뉴 삭제 및 전체 비우기
* 장바구니 REST API 엔드포인트 구현 (Controller)


### 리뷰요청
* 현재 CartService 테스트를 위한 임시 Menu/Company 데이터 DML 포함해서 테스트 했습니다
* 장바구니에 담긴 메뉴의 수량을 0으로 설정했을 때 삭제되게 처리했는데 0으로 설정을 못하게 하는 것이 나을까요??
* Entity 편의 메서드가 적절하게 구현되었는지
* Service 로직에 불필요한 부분이나 개선 가능한 부분이 있는지
* 비즈니스 규칙 (같은 가게만, 권한 확인)이 제대로 적용되었는지
* DTO validation이 적절한지
* 예외 처리가 누락된 케이스가 있는지
* 네이밍 컨벤션이 프로젝트 규칙과 일치하는지