### PR TITLE
[feat] 회원가입 시 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	//security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	//email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	// JWT
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.sparta.vroomvroom.domain.user.model.dto.request.UserLoginRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserSignupRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserUpdatedRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.response.UserDetailResponse;
+import com.sparta.vroomvroom.domain.user.service.EmailService;
 import com.sparta.vroomvroom.domain.user.service.UserService;
 import com.sparta.vroomvroom.global.conmon.BaseResponse;
 import com.sparta.vroomvroom.global.conmon.swagger.SwaggerDescription;
@@ -23,13 +24,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final EmailService emailService;
     private final JwtUtil jwtUtil;
 
-    @PostMapping("/users/login")
+    @PostMapping("/v1/users/login")
     @Operation(summary = "로그인 (Swagger용)", description = "실제 인증은 SecurityFilter에서 처리")
     public ResponseEntity<Void> swaggerLogin(
             @RequestBody UserLoginRequest loginRequest
@@ -38,7 +40,7 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
-    @PostMapping("/users/logout")
+    @PostMapping("/v1/users/logout")
     @Operation(summary = "로그아웃 (Swagger용)", description = "실제 인증은 SecurityFilter에서 처리")
     public ResponseEntity<Void> swaggerLogout(
     ) {
@@ -47,7 +49,7 @@ public class UserController {
     }
 
     //회원 가입
-    @PostMapping("/users/signup")
+    @PostMapping("/v1/users/signup")
     @Operation(summary = "회원가입 API", description = SwaggerDescription.USER_SIGNUP_REQUEST,
             requestBody =  @io.swagger.v3.oas.annotations.parameters.RequestBody (
                     content = @Content(
@@ -65,7 +67,7 @@ public class UserController {
     }
 
     //회원 정보 조회
-    @GetMapping("/users")
+    @GetMapping("/v1/users")
     @Operation(summary = "회원 정보 조회 API", description = "로그인한 회원의 정보를 조회해오는 API입니다. 로그인 후 이용 가능합니다.")
     public BaseResponse<UserDetailResponse> getUser(
             @AuthenticationPrincipal UserDetailsImpl userDetails
@@ -75,8 +77,8 @@ public class UserController {
     }
 
     //회원 정보 수정
-    @PatchMapping("/users")
-    @PostMapping("/users/signup")
+    @PatchMapping("/v1/users")
+    @PostMapping("/v1/users/signup")
     @Operation(summary = "회원 정보 수정 API", description = SwaggerDescription.USER_DETAIL_UPDATE_REQUEST,
             requestBody =  @io.swagger.v3.oas.annotations.parameters.RequestBody (
                     content = @Content(
@@ -98,7 +100,7 @@ public class UserController {
     }
 
     //회원 탈퇴
-    @DeleteMapping("/users")
+    @DeleteMapping("/v1/users")
     @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴 API 입니다. softDelete 처리 되며 로그인 후 이용 가능합니다.")
     public BaseResponse deleteUser(
             HttpServletRequest req,
@@ -110,7 +112,7 @@ public class UserController {
     }
 
     //비밀번호 변경
-    @PatchMapping("/users/password")
+    @PatchMapping("/v1/users/password")
     @Operation(summary = "비밀번호 변경 API", description = SwaggerDescription.USER_PASSWORD_CHANGE_REQUEST,
             requestBody =  @io.swagger.v3.oas.annotations.parameters.RequestBody (
                     content = @Content(
@@ -125,6 +127,19 @@ public class UserController {
             @RequestBody UserChangePasswordRequest req
     ){
         userService.changePassword(userDetails.getUser().getUserName(),req);
+        return new BaseResponse();
+    }
+
+    @PostMapping("/v2/email/request")
+    @Operation(summary = "이메일 인증 요청 API", description = "회원 가입에 사용할 이메일로 인증 메일 발송을 요청합니다.")
+    public BaseResponse requestVerification(@RequestParam String email) {
+        emailService.sendVerificationMail(email);
+        return new BaseResponse();
+    }
+
+    @GetMapping("/v2/email/verify")
+    public BaseResponse verifyEmail(@RequestParam String email, @RequestParam String code) {
+        emailService.verifyEmail(email, code);
         return new BaseResponse();
     }
 

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/EmailVerification.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/EmailVerification.java
@@ -1,0 +1,46 @@
+package com.sparta.vroomvroom.domain.user.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "email_verification")
+@Getter
+@NoArgsConstructor
+public class EmailVerification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "code", nullable = false)
+    private String code;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "is_verified")
+    private boolean isVerified;
+
+    public EmailVerification(String email, String code, LocalDateTime expiresAt) {
+        this.email = email;
+        this.code = code;
+        this.expiresAt = expiresAt;
+        this.isVerified = false;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void verify() {
+        this.isVerified = true;
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/user/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/repository/EmailVerificationRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.vroomvroom.domain.user.repository;
+
+import com.sparta.vroomvroom.domain.user.model.entity.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, UUID> {
+    Optional<EmailVerification> findByEmail(String email);
+    Optional<EmailVerification> findByEmailAndCode(String email, String code);
+    void deleteAllByEmail(String email);
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/user/service/EmailService.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/service/EmailService.java
@@ -1,0 +1,94 @@
+package com.sparta.vroomvroom.domain.user.service;
+
+import com.sparta.vroomvroom.domain.user.model.entity.EmailVerification;
+import com.sparta.vroomvroom.domain.user.repository.EmailVerificationRepository;
+import com.sparta.vroomvroom.global.conmon.constants.EmailTemplate;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final JavaMailSender mailSender;
+
+    private static final String VERIFY_URL = "http://localhost:8080/api/v2/email/verify?email=%s&code=%s";
+    private static final int EXPIRATION_MINUTES = 10;
+
+    @Value("${spring.mail.username}")
+    private String senderEmail;
+
+    //인증 코드 전송
+    @Transactional
+    public void sendVerificationMail(String email) {
+        //기존에 인증 요청 있다면 전부 삭제
+        emailVerificationRepository.deleteAllByEmail(email);
+
+        String code = UUID.randomUUID().toString().substring(0, 8);
+        String verifyLink = String.format(VERIFY_URL, email, code);
+
+        EmailVerification verification = new EmailVerification(email,code, LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES));
+        emailVerificationRepository.save(verification);
+
+        //전송 본문 완성
+        String subject = EmailTemplate.EMAIL_VERIFY_REQUEST.getSubject();
+        String content = EmailTemplate.EMAIL_VERIFY_REQUEST.buildContent(verifyLink,EXPIRATION_MINUTES);
+
+        // 메일 발송
+        sendHtmlMail(email, subject, content);
+    }
+
+    //이메일 인증 여부 체크
+    public void isVerified(String email) {
+        EmailVerification verification = emailVerificationRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("이메일 인증이 필요합니다."));
+
+        if (!verification.isVerified()) {
+            throw new IllegalArgumentException("이메일 인증이 완료되지 않았습니다.");
+        }
+
+        if (verification.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("이메일 인증 코드가 만료되었습니다.");
+        }
+    }
+    public void deleteEmailVerification(String email) {
+        emailVerificationRepository.deleteAllByEmail(email);
+    }
+
+    //이메일 검증
+    @Transactional
+    public void verifyEmail(String email, String code) {
+        EmailVerification verification = emailVerificationRepository.findByEmailAndCode(email, code)
+                .orElseThrow(() -> new IllegalArgumentException("인증 요청이 존재하지 않습니다."));
+
+        if (verification.isExpired()) {
+            throw new IllegalArgumentException("인증 코드가 만료되었습니다.");
+        }
+
+        verification.verify();
+    }
+
+    //html 메일 전송
+    private void sendHtmlMail(String to, String subject, String htmlContent) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setTo(to);
+            helper.setFrom(senderEmail);
+            helper.setSubject(subject);
+            helper.setText(htmlContent, true);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("메일 발송 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/service/UserService.java
@@ -5,26 +5,38 @@ import com.sparta.vroomvroom.domain.user.model.dto.request.UserSignupRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserUpdatedRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.response.UserDetailResponse;
 import com.sparta.vroomvroom.domain.user.model.entity.BlackList;
+import com.sparta.vroomvroom.domain.user.model.entity.EmailVerification;
 import com.sparta.vroomvroom.domain.user.model.entity.User;
 import com.sparta.vroomvroom.domain.user.repository.BlackListRepository;
+import com.sparta.vroomvroom.domain.user.repository.EmailVerificationRepository;
 import com.sparta.vroomvroom.domain.user.repository.UserRepository;
+import com.sparta.vroomvroom.global.conmon.constants.EmailTemplate;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
-    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
+    private final UserRepository userRepository;
     private final BlackListRepository blackListRepository;
+    private final EmailService emailService;
 
     //아이디, 전화번호, 이메일 셋 중 하나라도 기존 회원의 값과 중복되면 가입 불가
     //중복 체크 -> 회원 생성 처리 -> DB insert
+    @Transactional
     public void signup(UserSignupRequest req) {
         //중복 체크 (기존 회원 존재시 예외 발생)
         userRepository.findByUserNameOrEmailOrPhoneNumberAndNotDeleted(req.getUserName(),req.getEmail(),req.getPhoneNumber())
@@ -32,10 +44,16 @@ public class UserService {
                     throw new IllegalArgumentException("입력한 정보로 이미 가입된 회원이 존재합니다.");
                 });
 
+        //이메일 인증여부 체크
+        emailService.isVerified(req.getEmail());
+
         //회원 저장
         User user = new User(req, passwordEncoder.encode(req.getPassword()));
         user.create(req.getUserName());
         userRepository.save(user);
+
+        //인증 정보 삭제
+        emailService.deleteEmailVerification(user.getEmail());
     }
 
     //회원 정보 조회
@@ -111,4 +129,8 @@ public class UserService {
         );
         return user;
     }
+
+
+
+
 }

--- a/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/vroomvroom/global/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
                 //인증 인가 규칙
                 //Todo: v1개발 진척도에 따라 세부 조정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/users/login","/api/v1/users/signup").permitAll()
+                        .requestMatchers("/api/v1/users/login","/api/v1/users/signup", "/api/v2/email/**").permitAll()
                         .requestMatchers("/api/v1/users/logout").authenticated()
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/com/sparta/vroomvroom/global/conmon/constants/EmailTemplate.java
+++ b/src/main/java/com/sparta/vroomvroom/global/conmon/constants/EmailTemplate.java
@@ -1,0 +1,25 @@
+package com.sparta.vroomvroom.global.conmon.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailTemplate {
+    EMAIL_VERIFY_REQUEST(
+            "VroomVroom 이메일 인증 안내",
+            """
+            <h2>이메일 인증 안내</h2>
+            <p>아래 링크를 클릭하여 이메일 인증을 완료해주세요.</p>
+            <a href="%s" target="_blank">이메일 인증하기</a>
+            <p>유효시간: %d분</p>
+            """
+    );
+
+    private final String subject;
+    private final String content;
+
+    public String buildContent(Object... args){
+        return content.formatted(args);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,18 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  mail:
+    host: smtp.naver.com
+    port: 587
+    username: ${EMAIL} #이메일 발송에 사용할 네이버 아이디 ~~~@naver.com
+    password: ${EMAIL_APP_PASSWORD}    # 앱 비밀번호 (계정 비번 아님!) 네이버ID -> 보안설정 -> 2단계 인증 관리 여기서 발급
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+    default-encoding: UTF-8
 
 server:
   port: ${SERVER_PORT:8080}


### PR DESCRIPTION
### 관련 이슈
#57 

### 변경사항
- 이메일 인증 관련 테이블 추가
- 이메일을 기준으로 테이블에 데이터 삽입 및 삭제
- 이메일로 전송된 검증 링크 클릭 시 테이블 데이터 인증결과를 true로 수정하도록 구현
- 회원가입 시 이메일 인증을 하지 않으면 가입되지 않도록 로직 수정

### 리뷰요청
> 환경변수 2개 추가 (노션 페이지에 기본값은 세팅, 추후 개인 이메일과 비밀번호로 변경)
EMAIL, EMAIL_APP_PASSWORD 추가후 값 세팅하고 테스트 부탁드립니다~!

- 이메일 인증요청 없이 회원가입 불가능 하도록 구현되었는지
- 인증 요청만하고 검증링크 클릭하지 않았을 시 회원가입 불가능 하도록 구현 되었는지
- 만료시간 10분이 지난 후 클릭하면 인증이 실패 처리 되는지
- 인증이 성공하고 회원가입이 정상 처리되는지
- 회원가입이 되면 기존 인증 테이블 데이터가 잘 삭제되는지