### PR TITLE
[feat] 관리자용 기능 구현 완료

### DIFF
--- a/src/main/java/com/sparta/vroomvroom/domain/cart/repository/CartMenuRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/cart/repository/CartMenuRepository.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 
 public interface CartMenuRepository extends JpaRepository<CartMenu, UUID> {
 
+    List<CartMenu> findAllByCart_CartId(UUID cartId);
+
     List<CartMenu> findByCart_CartId(UUID cartId);
 
     Optional<CartMenu> findByCart_CartIdAndMenu_MenuId(UUID cartId, UUID menuId);

--- a/src/main/java/com/sparta/vroomvroom/domain/company/repository/CompanyRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/company/repository/CompanyRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CompanyRepository extends JpaRepository<Company, UUID>, CompanyRepositoryCustom {
@@ -21,4 +22,6 @@ public interface CompanyRepository extends JpaRepository<Company, UUID>, Company
     List<Company> findAllByIsDeletedFalse();
 
     Page<Company> findAllByIsDeletedFalseAndCompanyCategory_CompanyCategoryId(UUID companyCategoryId, Pageable pageable);
+
+    Optional<Company> findByUser_UserId(Long userId);
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/controller/ManagerController.java
@@ -77,7 +77,7 @@ public class ManagerController {
     }
 
     @Operation(summary = "관리자용 주문 취소처리 API")
-    @GetMapping("/v1/manager/orders/{orderId}")
+    @DeleteMapping("/v1/manager/orders/{orderId}")
     @Secured({"ROLE_MANAGER","ROLE_MASTER"})
     public BaseResponse cancleOrder(@PathVariable UUID orderId) {
         managerService.cancleOrder(orderId);
@@ -85,7 +85,7 @@ public class ManagerController {
     }
 
     @Operation(summary = "관리자용 회원 삭제 API")
-    @GetMapping("/v1/manager/users/{userId}")
+    @DeleteMapping("/v1/manager/users/{userId}")
     @Secured({"ROLE_MANAGER","ROLE_MASTER"})
     public BaseResponse deleteUser(@PathVariable Long userId) {
         managerService.deleteUser(userId);
@@ -93,7 +93,7 @@ public class ManagerController {
     }
 
     @Operation(summary = "관리자용 업체 삭제 API")
-    @GetMapping("/v1/manager/companies/{companyId}")
+    @DeleteMapping("/v1/manager/companies/{companyId}")
     @Secured({"ROLE_MANAGER","ROLE_MASTER"})
     public BaseResponse deleteCompany(@PathVariable UUID companyId) {
         managerService.deleteCompany(companyId);
@@ -101,7 +101,7 @@ public class ManagerController {
     }
 
     @Operation(summary = "관리자용 리뷰 삭제 API")
-    @GetMapping("/v1/manager/reviews/{reviewId}")
+    @DeleteMapping("/v1/manager/reviews/{reviewId}")
     @Secured({"ROLE_MANAGER","ROLE_MASTER"})
     public BaseResponse deleteReview(@PathVariable UUID reviewId) {
         managerService.deleteReview(reviewId);

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/controller/ManagerController.java
@@ -1,17 +1,23 @@
 package com.sparta.vroomvroom.domain.manager.controller;
 
+import com.sparta.vroomvroom.domain.manager.model.dto.request.ManagerRegisterRequest;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerCompanyResponse;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerOrderResponse;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerReviewResponse;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerUserResponse;
 import com.sparta.vroomvroom.domain.manager.service.ManagerService;
 import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import com.sparta.vroomvroom.global.conmon.swagger.SwaggerDescription;
+import com.sparta.vroomvroom.global.conmon.swagger.SwaggerExamples;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api")
@@ -20,6 +26,23 @@ public class ManagerController {
 
     private final ManagerService managerService;
 
+    @Operation(summary = "MASTER용 MANAGER 생성 API",description = SwaggerDescription.MANAGER_REGISTER_REQUEST,
+            requestBody =  @io.swagger.v3.oas.annotations.parameters.RequestBody (
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(value = SwaggerExamples.MANAGER_REGISTER_REQUEST)
+                            }
+                    )
+            ))
+    @PostMapping("/v1/manager/register")
+    @Secured({"ROLE_MASTER"})
+    public BaseResponse createManager(
+            @RequestBody ManagerRegisterRequest request
+            ) {
+        managerService.createManager(request);
+        return new BaseResponse<>();
+    }
 
     @Operation(summary = "관리자용 전체 주문 목록 조회 API")
     @GetMapping("/v1/manager/orders")
@@ -51,6 +74,38 @@ public class ManagerController {
     public BaseResponse<List<ManagerReviewResponse>> getReviews() {
         List<ManagerReviewResponse> response = managerService.getReviews();
         return new BaseResponse<>(response);
+    }
+
+    @Operation(summary = "관리자용 주문 취소처리 API")
+    @GetMapping("/v1/manager/orders/{orderId}")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse cancleOrder(@PathVariable UUID orderId) {
+        managerService.cancleOrder(orderId);
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "관리자용 회원 삭제 API")
+    @GetMapping("/v1/manager/users/{userId}")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse deleteUser(@PathVariable Long userId) {
+        managerService.deleteUser(userId);
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "관리자용 업체 삭제 API")
+    @GetMapping("/v1/manager/companies/{companyId}")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse deleteCompany(@PathVariable UUID companyId) {
+        managerService.deleteCompany(companyId);
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "관리자용 리뷰 삭제 API")
+    @GetMapping("/v1/manager/reviews/{reviewId}")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse deleteReview(@PathVariable UUID reviewId) {
+        managerService.deleteReview(reviewId);
+        return new BaseResponse<>();
     }
 
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/controller/ManagerController.java
@@ -1,0 +1,56 @@
+package com.sparta.vroomvroom.domain.manager.controller;
+
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerCompanyResponse;
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerOrderResponse;
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerReviewResponse;
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerUserResponse;
+import com.sparta.vroomvroom.domain.manager.service.ManagerService;
+import com.sparta.vroomvroom.global.conmon.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ManagerController {
+
+    private final ManagerService managerService;
+
+
+    @Operation(summary = "관리자용 전체 주문 목록 조회 API")
+    @GetMapping("/v1/manager/orders")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse<List<ManagerOrderResponse>> getOrders() {
+        List<ManagerOrderResponse> response = managerService.getOrders();
+        return new BaseResponse<>(response);
+    }
+
+    @Operation(summary = "관리자용 전체 사용자 목록 조회 API")
+    @GetMapping("/v1/manager/users")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse<List<ManagerUserResponse>> getUsers() {
+        List<ManagerUserResponse> response = managerService.getUsers();
+        return new BaseResponse<>(response);
+    }
+
+    @Operation(summary = "관리자용 전체 업체 목록 조회 API")
+    @GetMapping("/v1/manager/companies")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse<List<ManagerCompanyResponse>> getCompanies() {
+        List<ManagerCompanyResponse> response = managerService.getCompanies();
+        return new BaseResponse<>(response);
+    }
+
+    @Operation(summary = "관리자용 전체 리뷰 목록 조회 API")
+    @GetMapping("/v1/manager/reviews")
+    @Secured({"ROLE_MANAGER","ROLE_MASTER"})
+    public BaseResponse<List<ManagerReviewResponse>> getReviews() {
+        List<ManagerReviewResponse> response = managerService.getReviews();
+        return new BaseResponse<>(response);
+    }
+
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/request/ManagerRegisterRequest.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/request/ManagerRegisterRequest.java
@@ -1,0 +1,60 @@
+package com.sparta.vroomvroom.domain.manager.model.dto.request;
+
+import com.sparta.vroomvroom.global.conmon.constants.UserType;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class ManagerRegisterRequest {
+    @NotBlank(message = "아이디는 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^[a-zA-Z0-9]{4,10}$",
+            message = "아이디는 영문과 숫자로 4~10자만 가능합니다.")
+    private String userName;
+
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{8,15}$",
+            message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함해 8~15자여야 합니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^[a-zA-Z0-9가-힣]{5,20}$",
+            message = "닉네임은 영문/한글/숫자로 5~20자만 가능합니다.")
+    private String nickName;
+
+    @NotNull(message = "회원 타입은 필수 입력 항목입니다.")
+    private UserType type;
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^[a-zA-Z가-힣]{1,20}$",
+            message = "이름은 영문과 한글만, 최대 20자까지 가능합니다.")
+    private String name;
+
+    @NotNull(message = "생일은 필수 입력 항목입니다.")
+    @Past(message = "생일은 오늘 이전 날짜여야 합니다.")
+    private LocalDate birthDate;
+
+    @NotBlank(message = "성별은 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^[가-힣]+$",
+            message = "성별은 한글만 입력 가능합니다.")
+    private String gender;
+
+    @NotBlank(message = "휴대폰 번호는 공백일 수 없습니다.")
+    @Pattern(
+            regexp = "^\\d{3}-\\d{4}-\\d{4}$",
+            message = "휴대폰 번호는 000-0000-0000 형식만 가능합니다.")
+    private String phoneNumber;
+
+    @NotBlank(message = "이메일은 공백일 수 없습니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Size(max = 50, message = "이메일은 최대 50자까지 가능합니다.")
+    private String email;
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerCompanyResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerCompanyResponse.java
@@ -1,0 +1,20 @@
+package com.sparta.vroomvroom.domain.manager.model.dto.response;
+
+import com.sparta.vroomvroom.domain.company.model.entity.Company;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ManagerCompanyResponse {
+
+    private UUID companyId;
+    private String companyName;
+
+    public ManagerCompanyResponse(Company company) {
+        this.companyId = company.getCompanyId();
+        this.companyName = company.getCompanyName();
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerOrderResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerOrderResponse.java
@@ -1,0 +1,25 @@
+package com.sparta.vroomvroom.domain.manager.model.dto.response;
+
+import com.sparta.vroomvroom.domain.order.model.entity.Order;
+import com.sparta.vroomvroom.global.conmon.constants.OrderStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ManagerOrderResponse {
+
+    private UUID orderId;
+    private Long userId;
+    private UUID companyId;
+    private OrderStatus orderStatus;
+
+    public ManagerOrderResponse(Order order) {
+        this.orderId = order.getOrderId();
+        this.orderStatus = order.getOrderStatus();
+        this.companyId = order.getCompany().getCompanyId();
+        this.userId = order.getUser().getUserId();
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerOwnerReviewResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerOwnerReviewResponse.java
@@ -1,0 +1,20 @@
+package com.sparta.vroomvroom.domain.manager.model.dto.response;
+
+import com.sparta.vroomvroom.domain.review.model.entity.OwnerReview;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ManagerOwnerReviewResponse {
+
+    private UUID ownerReviewId;
+    private String contents;
+
+    public ManagerOwnerReviewResponse(OwnerReview ownerReview) {
+        this.ownerReviewId = ownerReview.getId();
+        this.contents = ownerReview.getContents();
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerReviewResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerReviewResponse.java
@@ -1,0 +1,21 @@
+package com.sparta.vroomvroom.domain.manager.model.dto.response;
+
+import com.sparta.vroomvroom.domain.review.model.entity.Review;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ManagerReviewResponse {
+    private UUID reviewId;
+    private String contents;
+    private ManagerOwnerReviewResponse ownerReview;
+
+    public ManagerReviewResponse(Review review) {
+        this.reviewId = review.getId();
+        this.contents = review.getContents();
+        this.ownerReview = new ManagerOwnerReviewResponse(review.getOwnerReview());
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerUserResponse.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/model/dto/response/ManagerUserResponse.java
@@ -1,0 +1,21 @@
+package com.sparta.vroomvroom.domain.manager.model.dto.response;
+
+import com.sparta.vroomvroom.domain.user.model.entity.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ManagerUserResponse {
+    private Long userId;
+    private String userName;
+    private String phoneNumber;
+    private String email;
+
+    public ManagerUserResponse(User user) {
+        this.userId = user.getUserId();
+        this.userName = user.getUserName();
+        this.phoneNumber = user.getPhoneNumber();
+        this.email = user.getEmail();
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/service/ManagerService.java
@@ -1,0 +1,64 @@
+package com.sparta.vroomvroom.domain.manager.service;
+
+import com.sparta.vroomvroom.domain.company.model.entity.Company;
+import com.sparta.vroomvroom.domain.company.repository.CompanyRepository;
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerCompanyResponse;
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerOrderResponse;
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerReviewResponse;
+import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerUserResponse;
+import com.sparta.vroomvroom.domain.order.model.entity.Order;
+import com.sparta.vroomvroom.domain.order.repository.OrderRepository;
+import com.sparta.vroomvroom.domain.review.model.entity.Review;
+import com.sparta.vroomvroom.domain.review.repository.ReviewRepository;
+import com.sparta.vroomvroom.domain.user.model.entity.User;
+import com.sparta.vroomvroom.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerService {
+
+    private final OrderRepository orderRepository;
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final CompanyRepository companyRepository;
+
+
+    public List<ManagerOrderResponse> getOrders() {
+        List<Order> order = orderRepository.findAll();
+        List<ManagerOrderResponse> response = order.stream()
+                .map(ManagerOrderResponse::new)
+                .toList();
+        return response;
+    }
+
+
+    public List<ManagerUserResponse> getUsers() {
+        List<User> user = userRepository.findAll();
+        List<ManagerUserResponse> response = user.stream()
+                .map(ManagerUserResponse::new)
+                .toList();
+        return response;
+    }
+
+    public List<ManagerCompanyResponse> getCompanies() {
+        List<Company> company = companyRepository.findAll();
+        List<ManagerCompanyResponse> response = company.stream()
+                .map(ManagerCompanyResponse::new)
+                .toList();
+        return response;
+    }
+
+
+    public List<ManagerReviewResponse> getReviews() {
+        List<Review> review = reviewRepository.findAll();
+        List<ManagerReviewResponse> response = review.stream()
+                .map(ManagerReviewResponse::new)
+                .toList();
+        return response;
+    }
+}

--- a/src/main/java/com/sparta/vroomvroom/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/manager/service/ManagerService.java
@@ -1,22 +1,40 @@
 package com.sparta.vroomvroom.domain.manager.service;
 
+import com.sparta.vroomvroom.domain.address.model.entity.Address;
+import com.sparta.vroomvroom.domain.address.repository.AddressRepository;
+import com.sparta.vroomvroom.domain.cart.model.entity.Cart;
+import com.sparta.vroomvroom.domain.cart.model.entity.CartMenu;
+import com.sparta.vroomvroom.domain.cart.repository.CartMenuRepository;
+import com.sparta.vroomvroom.domain.cart.repository.CartRepository;
+import com.sparta.vroomvroom.domain.company.model.entity.BusinessHour;
 import com.sparta.vroomvroom.domain.company.model.entity.Company;
+import com.sparta.vroomvroom.domain.company.model.entity.SpecialBusinessHour;
+import com.sparta.vroomvroom.domain.company.repository.BusinessHourRepository;
 import com.sparta.vroomvroom.domain.company.repository.CompanyRepository;
+import com.sparta.vroomvroom.domain.company.repository.SpecialBusinessHourRepository;
+import com.sparta.vroomvroom.domain.manager.model.dto.request.ManagerRegisterRequest;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerCompanyResponse;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerOrderResponse;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerReviewResponse;
 import com.sparta.vroomvroom.domain.manager.model.dto.response.ManagerUserResponse;
 import com.sparta.vroomvroom.domain.order.model.entity.Order;
 import com.sparta.vroomvroom.domain.order.repository.OrderRepository;
+import com.sparta.vroomvroom.domain.payments.model.entity.Payment;
+import com.sparta.vroomvroom.domain.payments.repository.PaymentRepository;
 import com.sparta.vroomvroom.domain.review.model.entity.Review;
 import com.sparta.vroomvroom.domain.review.repository.ReviewRepository;
 import com.sparta.vroomvroom.domain.user.model.entity.User;
 import com.sparta.vroomvroom.domain.user.repository.UserRepository;
+import com.sparta.vroomvroom.global.conmon.constants.UserRole;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -26,39 +44,138 @@ public class ManagerService {
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
+    private final CartRepository cartRepository;
+    private final CartMenuRepository cartMenuRepository;
+    private final PaymentRepository paymentRepository;
+    private final AddressRepository addressRepository;
+    private final BusinessHourRepository businessHourRepository;
+    private final SpecialBusinessHourRepository specialBusinessHourRepository;
+    private final PasswordEncoder passwordEncoder;
 
 
     public List<ManagerOrderResponse> getOrders() {
-        List<Order> order = orderRepository.findAll();
-        List<ManagerOrderResponse> response = order.stream()
+        List<Order> order = orderRepository.findAllByIsDeletedFalse();
+        return order.stream()
                 .map(ManagerOrderResponse::new)
                 .toList();
-        return response;
     }
 
 
     public List<ManagerUserResponse> getUsers() {
-        List<User> user = userRepository.findAll();
-        List<ManagerUserResponse> response = user.stream()
+        List<User> user = userRepository.findAllByIsDeletedFalse();
+        return user.stream()
                 .map(ManagerUserResponse::new)
                 .toList();
-        return response;
     }
 
     public List<ManagerCompanyResponse> getCompanies() {
-        List<Company> company = companyRepository.findAll();
-        List<ManagerCompanyResponse> response = company.stream()
+        List<Company> company = companyRepository.findAllByIsDeletedFalse();
+        return company.stream()
                 .map(ManagerCompanyResponse::new)
                 .toList();
-        return response;
     }
 
 
     public List<ManagerReviewResponse> getReviews() {
-        List<Review> review = reviewRepository.findAll();
-        List<ManagerReviewResponse> response = review.stream()
+        List<Review> review = reviewRepository.findAllByIsDeletedFalse();
+        return review.stream()
                 .map(ManagerReviewResponse::new)
                 .toList();
-        return response;
+    }
+
+    @Transactional
+    public void cancleOrder(UUID orderId) {
+        boolean isRefund = false;
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않거나 유효하지 않은 주문입니다.")
+        );
+        //주문 취소
+        order.cancel("관리자에 의한 취소처리", UserRole.ROLE_MANAGER.getRole());
+        //환불
+        Payment payment = paymentRepository.findByOrder_OrderId(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("결제 정보를 찾을 수 없습니다."));
+
+        payment.refund(UserRole.ROLE_MANAGER.getRole());
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                ()-> new IllegalArgumentException("존재하지 않는 회원입니다.")
+        );
+        if(user.getRole() == UserRole.ROLE_MASTER){
+            throw new IllegalArgumentException("MASTER는 삭제할 수 없습니다.");
+        }
+        Optional<Cart> cart = cartRepository.findByUser_UserId(userId);
+
+        Optional<Company> company = companyRepository.findByUser_UserId(userId);
+        //회원 삭제
+        user.softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());
+
+        //업체 존재시 삭제
+        if(company.isPresent()){
+            deleteCompany(company.get().getCompanyId());
+        }
+
+        //장바구니 삭제
+        if(cart.isPresent()){
+            cart.get().softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());
+            //장바구니에 담긴 메뉴 삭제 (물리 삭제)
+            List<CartMenu> cartMenus = cartMenuRepository.findAllByCart_CartId(cart.get().getCartId());
+            cartMenuRepository.deleteAll(cartMenus);
+        }
+
+        //주소 목록 삭제
+        List<Address> addresses = addressRepository.findAllByUserId(userId);
+        addresses.forEach(address -> {address.softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());});
+
+
+    }
+
+    @Transactional
+    public void deleteCompany(UUID companyId) {
+        Company company = companyRepository.findById(companyId).orElseThrow(
+                ()-> new IllegalArgumentException("존재하지 않는 업체입니다.")
+        );
+        company.softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());
+
+        List<BusinessHour> businessHours = businessHourRepository.findAllByCompanyId(companyId);
+        List<SpecialBusinessHour> specialBusinessHours = specialBusinessHourRepository.findAllByCompany_CompanyIdAndIsDeletedFalse(companyId);
+        List<Review> reviews = reviewRepository.findAllByCompany_CompanyId(companyId);
+        //영업시간 삭제
+        businessHours.forEach(businessHour -> {businessHour.softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());});
+        //특별 영업시간 삭제
+        specialBusinessHours.forEach(specialBusinessHour -> {specialBusinessHour.softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());});
+        //리뷰 삭제
+        reviews.forEach(review -> {
+            review.softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());
+            if(review.getOwnerReview() != null){
+                review.getOwnerReview().softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());
+            }
+        });
+
+    }
+
+    @Transactional
+    public void deleteReview(UUID reviewId) {
+        Review review = reviewRepository.findById(reviewId).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 리뷰입니다.")
+        );
+        //사장님 리뷰 있으면 삭제
+        if(review.getOwnerReview() != null){
+            review.getOwnerReview().softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());
+        }
+        //리뷰 삭제
+        review.softDelete(LocalDateTime.now(), UserRole.ROLE_MANAGER.getRole());
+    }
+
+    public void createManager(ManagerRegisterRequest request) {
+        userRepository.findByUserNameOrEmailOrPhoneNumberAndNotDeleted(request.getUserName(), request.getEmail(), request.getPhoneNumber())
+                .ifPresent(user -> {
+                            throw new IllegalArgumentException("입력한 정보로 이미 가입된 회원이 존재합니다.");
+                });
+        User user = new User(request, passwordEncoder.encode(request.getPassword()));
+        user.create(UserRole.ROLE_MASTER.getRole());
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/order/repository/OrderRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
@@ -49,4 +50,6 @@ public interface OrderRepository extends JpaRepository<Order, UUID> {
             LocalDateTime endDate,
             Pageable pageable
     );
+
+    List<Order> findAllByIsDeletedFalse();
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/review/repository/ReviewRepository.java
@@ -21,4 +21,8 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     List<Review> findByCompany_CompanyIdAndId(UUID compId, UUID reviewId);
 
     Optional<Review> findByOrder_OrderId(UUID orderId);
+
+    List<Review> findAllByIsDeletedFalse();
+
+    List<Review> findAllByCompany_CompanyId(UUID companyCompanyId);
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/User.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/model/entity/User.java
@@ -1,5 +1,6 @@
 package com.sparta.vroomvroom.domain.user.model.entity;
 
+import com.sparta.vroomvroom.domain.manager.model.dto.request.ManagerRegisterRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserSignupRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserUpdatedRequest;
 import com.sparta.vroomvroom.global.conmon.BaseEntity;
@@ -57,6 +58,9 @@ public class User extends BaseEntity {
 
 
     public User(UserSignupRequest req, String encodedPassword) {
+        if(req.getRole() == UserRole.ROLE_MANAGER || req.getRole() != UserRole.ROLE_MASTER){
+            throw new IllegalArgumentException("설정할 수 없는 권한입니다. CUSTOMER, OWNER 둘 중 한 가지 권한으로만 가입할 수 있습니다..");
+        }
         this.userName = req.getUserName();
         this.password = encodedPassword;
         this.type = req.getType();
@@ -67,5 +71,19 @@ public class User extends BaseEntity {
         this.phoneNumber = req.getPhoneNumber();
         this.email = req.getEmail();
         this.role = req.getRole();
+
+    }
+
+    public User(ManagerRegisterRequest req, String encodedPassword) {
+        this.userName = req.getUserName();
+        this.password = encodedPassword;
+        this.type = req.getType();
+        this.nickName = req.getNickName();
+        this.name = req.getName();
+        this.birthDate = req.getBirthDate();
+        this.gender = req.getGender();
+        this.phoneNumber = req.getPhoneNumber();
+        this.email = req.getEmail();
+        this.role = UserRole.ROLE_MANAGER;
     }
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -20,4 +21,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByUserNameAndIsDeletedFalse(String userName);
+
+    List<User> findAllByIsDeletedFalse();
 }

--- a/src/main/java/com/sparta/vroomvroom/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/vroomvroom/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.sparta.vroomvroom.domain.user.service;
 
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeWithZoneIdSerializer;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserChangePasswordRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserSignupRequest;
 import com.sparta.vroomvroom.domain.user.model.dto.request.UserUpdatedRequest;
@@ -8,6 +9,7 @@ import com.sparta.vroomvroom.domain.user.model.entity.BlackList;
 import com.sparta.vroomvroom.domain.user.model.entity.User;
 import com.sparta.vroomvroom.domain.user.repository.BlackListRepository;
 import com.sparta.vroomvroom.domain.user.repository.UserRepository;
+import com.sparta.vroomvroom.global.conmon.constants.UserRole;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -84,7 +86,9 @@ public class UserService {
     @Transactional
     public void deleteUser(String userName, String token) {
         User user = findUser(userName);
-        //Todo: 시간을 외부에서 주입하지 말고 내부에서 쓰도록 변경(시간에 따른 서비스 로직 변화가 없음)
+        if(user.getRole() == UserRole.ROLE_MASTER){
+            throw new IllegalArgumentException("MASTER는 삭제할 수 없습니다.");
+        }
         user.softDelete(LocalDateTime.now(),user.getUserName());
         //삭제 처리 되면 현재 요청에서 사용한 토큰 무효화 (블랙리스트 처리)
         blackListRepository.save(new BlackList(token));

--- a/src/main/java/com/sparta/vroomvroom/global/conmon/swagger/SwaggerDescription.java
+++ b/src/main/java/com/sparta/vroomvroom/global/conmon/swagger/SwaggerDescription.java
@@ -50,6 +50,8 @@ public class SwaggerDescription {
             "회원가입과 로그인 진행 후 주문 생성 요청을 해주세요.<br>" +
             "companyId 값과 userAddressId 값이 필요합니다.<br>" +
             "요청 가능 권한 : customer";
+
+    //회원 가입 설명
     public static final String USER_SIGNUP_REQUEST = """
             userName, email, phoneNumber는 중복이 불가능 합니다.
             비밀번호는 대소문자,특수문자,숫자 모두를 포함해서 8~15자로 설정해주세요.
@@ -76,4 +78,10 @@ public class SwaggerDescription {
             "장바구니에 담긴 특정 메뉴의 수량/옵션을 수정합니다.<br>" +
                     "장바구니 조회 후 반환된 cartMenuId 값이 필요합니다.<br>" +
                     "요청 가능 권한 : customer";
+
+    //매니저 등록 설명
+    public static final String MANAGER_REGISTER_REQUEST = """
+            userName, email, phoneNumber는 중복이 불가능 합니다.
+            비밀번호는 대소문자,특수문자,숫자 모두를 포함해서 8~15자로 설정해주세요.
+            """;
 }

--- a/src/main/java/com/sparta/vroomvroom/global/conmon/swagger/SwaggerExamples.java
+++ b/src/main/java/com/sparta/vroomvroom/global/conmon/swagger/SwaggerExamples.java
@@ -138,4 +138,18 @@ public class SwaggerExamples {
               "menuAmount": 7
             }
             """;
+    //회원가입 예시
+    public static final String MANAGER_REGISTER_REQUEST = """
+            {
+              "userName": "testmanager0",
+              "password": "Abc123!@#",
+              "nickName": "매니저0번",
+              "type": "INAPP",
+              "name": "매니저a",
+              "birthDate": "1990-01-01",
+              "gender": "남",
+              "phoneNumber": "010-1919-1818",
+              "email": "testmanager0@vroomvroom.com"
+            }
+            """;
 }


### PR DESCRIPTION
### 관련 이슈
#64 

### 변경사항
- 관리자용 필수 도메인별 전체 조회 기능 구현
- 관리자용 필수 도메인 별 삭제 기능 구현
- 매니저 생성 기능 구현

### 리뷰요청
- 각 기능이 전부 동작하는지
- 삭제시 연관 데이터가 함께 삭제 처리 되는지 (유저: 만든 업체가 있다면 업체, 배송지, 장바구니가 있으면 장바구니 등이 함께 삭제 됨)
- 매니저 생성 기능은 MASTER만 동작시킬 수 있는지
- 기존 회원가입시 MANAGER,MASTER를 role에 넣을시 가입이 막히는지